### PR TITLE
[#103] LearningOutcomes.adoc: fix link to download code (#104)

### DIFF
--- a/docs/LearningOutcomes.adoc
+++ b/docs/LearningOutcomes.adoc
@@ -6,6 +6,7 @@
 :stylesDir: stylesheets
 ifdef::env-github[]
 :note-caption: :information_source:
+:site-githuburl: ../../../
 endif::[]
 
 After studying this code and completing the corresponding exercises, you should be able to,
@@ -24,7 +25,7 @@ Part A:
 
 Part B:
 
-* Download the source code for this project: Click on the `clone or download` link above and either,
+* Download the source code for this project: Click on the link:{site-githuburl}[`clone or download` button in the project's GitHub homepage] and either,
 . download as a zip file and unzip content.
 . clone the repo (if you know how to use Git) to your Computer.
 * <<DeveloperGuide#SettingUp, Set up>> the project in IntelliJ.


### PR DESCRIPTION
Before fb74fba, learning outcomes were written in README.adoc.
Developers were instructed to use the 'Clone or download' button
**above** the page, when viewing README.adoc on GitHub.

This instruction no longer make sense after learning outcomes have a
.adoc page on its own. Furthermore, the 'Clone or download' button will
not be available on the rendered static website version anyway, even if
it stayed in README.adoc.

Let's fix the instruction's link to download code, by using the
`site-githuburl` attribute declared in `build.gradle`. That attribute
will not be declared when viewing the .adoc page on GitHub, so declare a
separate attribute for `env-github` environment.